### PR TITLE
詳細ページデザイン修正

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -1549,8 +1549,12 @@ a {
 /* ---------- 企業詳細ページ ---------- */
 .detail {
   .title {
-    font-size: 16px;
+    font-size: 20px;
     margin-bottom: 4px;
+    > small {
+      font-size: 12px;
+      display: block;
+    }
     &__wrap {
       @include box;
       margin: 0 10px 10px;
@@ -1627,10 +1631,11 @@ a {
         top: -12px;
       }
       .title {
-        font-size: 16px;
+        font-size: 20px;
         margin-bottom: 8px;
         > small {
           font-size: 12px;
+          display: block;
         }
       }
       .characters {
@@ -1729,6 +1734,14 @@ a {
           width: calc(100% - 60px);
           padding: 12px;
           font-size: 12px;
+          .star {
+            font-size: 16px;
+            color: #2863a5;
+            small {
+              font-size: 12px;
+              display: block;
+            }
+          }
         }
       }
 
@@ -2070,6 +2083,7 @@ a {
           justify-content: space-between;
           align-items: center;
           margin-bottom: 10px;
+          line-height: 1.3;
           &__icon {
             font-size: 30px;
             width: 50px;
@@ -2079,11 +2093,16 @@ a {
             width: calc(100% - 50px);
           }
           &__name {
-            font-size: 14px;
+            font-size: 18px;
             font-weight: bold;
           }
           &__score {
-            font-size: 12px;
+            font-size: 18px;
+            margin-top: 8px;
+            > small {
+              font-size: 16px;
+              margin-left: 8px;
+            }
           }
         }
         &__text {
@@ -3052,6 +3071,28 @@ a {
     .title {
       &__wrap {
         margin: 0 0 10px;
+      }
+    }
+    .desc {
+      width: calc( 100% - 300px );
+      margin-left: 20px;
+      &__wrap {
+        display: flex;
+        justify-content: space-between;
+        align-items: start;
+        .image {
+          max-width: 300px;
+        }
+      }
+    }
+    &__datum {
+      .star {
+        font-size: 20px !important;
+        small {
+          font-size: 16px !important;
+          display: inline !important;
+          margin-left: 8px;
+        }
       }
     }
     &__job_wrap {

--- a/detail.html
+++ b/detail.html
@@ -41,7 +41,7 @@
     
     <div class="content">
       <div class="title__wrap">
-        <h1 class="title">リクルートエージェント<small>- 株式会社リクルートキャリア</small></h1>
+        <h1 class="title">リクルートエージェント<small>株式会社リクルートキャリア</small></h1>
         <ul class="title__list">
           <li><span class="title__star">★★★☆☆</span><span>3.16</span></li>
           <li>社員クチコミ3018件</li>
@@ -61,7 +61,7 @@
           <ul class="job_offers">
             <li>
               <p class="new">NEW</p>
-              <h2 class="title">リクルートエージェント<small>- 株式会社リクルートキャリア</small></h2>
+              <h2 class="title">リクルートエージェント<small>株式会社リクルートキャリア</small></h2>
               <ul class="characters">
                 <li class="character--blue">5h以内OK</li>
                 <li class="character--blue">残業少</li>
@@ -70,20 +70,21 @@
                 <li class="character--orange">派遣多</li>
                 <li class="character--orange">電話対応なし</li>
               </ul>
-              <div class="desc">
-                <h3 class="desc__head">働き方を選べるから、自分らしく働ける。長く活躍できる。</h3>
-                <p class="desc__text">テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト</p>
+              <div class="desc__wrap">
+                <img src="../kyujindb/images/sampleimg.jpg" class="image">
+                <div class="desc">
+                  <h3 class="desc__head">働き方を選べるから、自分らしく働ける。長く活躍できる。</h3>
+                  <p class="desc__text">テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト</p>
+                </div>
               </div>
-
-              <img src="../kyujindb/images/sampleimg.jpg" class="image">
-
               <div class="detail">
                 <div class="detail__top">
                   <div class ="detail__block--total">
                     <div class="detail__head">
                       <i class="fas fa-star"></i><span>総合評価</span>
                     </div>
-                    <div class="detail__datum">★★★☆☆ 3.16</div>
+                    <div class="detail__datum">
+                      <p class="star"><a href="#">★★★☆☆<small>3.16</small></a></p></div>
                   </div>
 
                   <div class ="detail__block--kuchikomi">
@@ -408,10 +409,10 @@
                           <i class="fas fa-user"></i>
                         </div>
                         <div class="content_head__text">
-                          <h3 class="content_head__name">エグゼクティブ・ハイクラス系 / 20代 / 男性 / 面談まで</h3>
-                          <div class="content_head__score">
-                            <p>★★★☆☆ 3.16</p>
-                          </div>
+                          <a href="#">
+                            <h3 class="content_head__name">エグゼクティブ・ハイクラス系 / 20代 / 男性 / 面談まで</h3>
+                            <div class="content_head__score">★★★☆☆<small>3.16</small></div>
+                          </a>
                         </div>
                       </div>
                       <p class="evaluation__text">


### PR DESCRIPTION
以下を対応。

■企業詳細
・サービス名
→もう少しサイズを上げて目立たせたい。企業名は小さくても良い。
・サイトキャプチャ
→可能であれば、グレー枠のサブタイトルと位置を逆にして特徴の下にサイトキャプチャを持ってきたい
・総合評価
→星と数字をもう少し目立たせたい。星と数字が2段になっても良い。文字をリンクテキストにして企業TOPに遷移。
・クチコミ
→もう少し目立たせたい。総合評価同様にリンクテキストにして口コミページに遷移。